### PR TITLE
Fix shadowdom test

### DIFF
--- a/extension/src/entrypoints/context.ts
+++ b/extension/src/entrypoints/context.ts
@@ -1,0 +1,23 @@
+export default defineContentScript({
+  matches: ['<all_urls>'],
+  // Run as early as possible to intercept shadow root creation
+  runAt: 'document_start',
+  main() {
+    const patch = `(
+      function() {
+        const original = Element.prototype.attachShadow;
+        Element.prototype.attachShadow = function(init) {
+          if (init && init.mode === 'closed') {
+            const newInit = Object.assign({}, init, { mode: 'open' });
+            return original.call(this, newInit);
+          }
+          return original.call(this, init);
+        };
+      }
+    )();`;
+    const script = document.createElement('script');
+    script.textContent = patch;
+    (document.documentElement || document.head).appendChild(script);
+    script.remove();
+  },
+});

--- a/workflows/tests/shadowdom-closed/shadow-closed.workflow.json
+++ b/workflows/tests/shadowdom-closed/shadow-closed.workflow.json
@@ -14,7 +14,7 @@
     {
       "description": "Type in inner input (closed)",
       "type": "input",
-      "cssSelector": "css=outer-closed >> deep=inner-closed >> deep=#inner-input",
+      "cssSelector": "css=outer-closed >> inner-closed >> #inner-input",
       "value": "hello-closed",
       "timeoutMs": 5000,
       "timestamp": 0,
@@ -23,7 +23,7 @@
     {
       "description": "Click inner button (closed)",
       "type": "click",
-      "cssSelector": "css=outer-closed >> deep=inner-closed >> deep=#inner-btn",
+      "cssSelector": "css=outer-closed >> inner-closed >> #inner-btn",
       "timeoutMs": 5000,
       "timestamp": 0,
       "tabId": 0
@@ -31,7 +31,7 @@
     {
       "description": "Click outer button (closed)",
       "type": "click",
-      "cssSelector": "css=outer-closed >> deep=#outer-btn",
+      "cssSelector": "css=outer-closed >> #outer-btn",
       "timeoutMs": 5000,
       "timestamp": 0,
       "tabId": 0

--- a/workflows/tests/shadowdom-closed/test_shadow_closed.py
+++ b/workflows/tests/shadowdom-closed/test_shadow_closed.py
@@ -48,7 +48,6 @@ async def launch_chromium_with_extension():
         f"--load-extension={EXT_DIR}",
     ]
     pw = await async_playwright().start()
-
     ctx = await pw.chromium.launch_persistent_context(
         tmp_profile, headless=True, args=args
     )
@@ -66,10 +65,10 @@ async def test_shadow_closed_workflow():
         )
         await workflow.run(close_browser_at_end=False)
 
-        # sanity-check: selector can pierce closed shadows
+        # sanity-check: patch opened closed shadow DOM so selectors work
         page  = ctx.pages[0] if ctx.pages else await ctx.new_page()
         value = await page.input_value(
-            "css=outer-closed >> deep=inner-closed >> deep=#inner-input"
+            "css=outer-closed >> inner-closed >> #inner-input"
         )
         assert value == "hello-closed"
     finally:


### PR DESCRIPTION
## Summary
- adjust app.js back to closed Shadow DOM
- add context script to patch attachShadow to always open
- restore extension loading in test

## Testing
- `pytest tests/shadowdom-closed -q` *(fails: Failed to find element)*